### PR TITLE
[#125]design: 우리팀 소개 페이지 헤더 수정

### DIFF
--- a/src/components/OurTeamIntro/Header/Header.jsx
+++ b/src/components/OurTeamIntro/Header/Header.jsx
@@ -28,10 +28,11 @@ const Header = () => {
       <S.HeaderWrapper>
         <S.BackButton onClick={() => navigate(-1)} />
         <S.Title>우리팀 소개</S.Title>
+        <S.DeleteButton onClick={handleDeleteClick}>
+          <S.DeleteIcon src={DeleteIcon} />
+        </S.DeleteButton>
       </S.HeaderWrapper>
-      <S.DeleteButton onClick={handleDeleteClick}>
-        <S.DeleteIcon src={DeleteIcon} />
-      </S.DeleteButton>
+
 
       {isDropdownOpen && (
         <S.DropdownMenu>

--- a/src/components/OurTeamIntro/Header/Styles.js
+++ b/src/components/OurTeamIntro/Header/Styles.js
@@ -12,6 +12,7 @@ export const Header = styled.div`
 export const HeaderWrapper = styled.div`
   display: flex;
   width: 86%;
+
 `;
 export const BackButton = styled(I.Back)`
   background: none;
@@ -30,16 +31,17 @@ export const Title = styled.h2`
 `;
 
 export const DeleteButton = styled.button`
+  display:flex;
+  position:absolute;
+  right:10%;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 3%;
-  margin-right: 2.5%;
+  margin-left:70%
 `;
 
 export const DeleteIcon = styled.img`
-  width: 25px;
-  height: 25px;
+
 `;
 
 export const DropdownMenu = styled.div`


### PR DESCRIPTION
## 🏁 요약
우리팀 소개 페이지 네비게이션 바 수정

<br>


## ✨ 주요 변경점
- 패딩 값 변환/컨테이너 레이아웃 변경




## 📸 스크린샷

![image](https://github.com/user-attachments/assets/90ca966c-2040-4e93-a07e-6da4c49c1b4f)


## 📚 참고사항
- 링크, 관련 자료 등

<br>