### PR TITLE
[#196] 회원정보수정 페이지 api 연결

### DIFF
--- a/src/api/Mypage/UpdateEmoji.ts
+++ b/src/api/Mypage/UpdateEmoji.ts
@@ -1,0 +1,31 @@
+import { privateAxios } from '../axiosConfig';
+
+export interface UpdateEmojiResponse {
+    status: string;
+    code: string;
+    message: string;
+    data: {
+        emoji: string;
+    };
+}
+
+export interface UpdateEmojiRequestType {
+    emoji: string;
+}
+
+export const updateEmoji = async (userData: UpdateEmojiRequestType): Promise<UpdateEmojiResponse | null> => {
+    try {
+        // console.log("PATCH 요청 보낼 데이터:", JSON.stringify(userData)); 
+
+        const { data } = await privateAxios.patch<UpdateEmojiResponse>(
+            `/user/myprofile/emoji`,
+            userData
+        );
+
+        // console.log("서버 응답 데이터:", data); 
+        return data;
+    } catch (error: any) {
+        // console.error("에러:", error.response?.data || error.message);
+        return null;
+    }
+};

--- a/src/api/Mypage/UpdateNickname.ts
+++ b/src/api/Mypage/UpdateNickname.ts
@@ -1,0 +1,31 @@
+import { privateAxios } from '../axiosConfig'; 
+
+export interface UpdateNicknameResponse {
+    status: string;
+    code: string;
+    message: string;
+    data: {
+        nickname: string;
+    };
+}
+
+export interface UpdateNicknameRequestType {
+    nickname: string;
+}
+
+export const updateNickname = async (userData: UpdateNicknameRequestType): Promise<UpdateNicknameResponse | null> => {
+    try {
+        // console.log("PATCH 요청 보낼 데이터:", JSON.stringify(userData)); 
+
+        const { data } = await privateAxios.patch<UpdateNicknameResponse>(
+            `/user/myprofile/nickname`,
+            userData
+        );
+
+        // console.log("서버 응답 데이터:", data); 
+        return data;
+    } catch (error: any) {
+        // console.error("에러:", error.response?.data || error.message);
+        return null;
+    }
+};

--- a/src/components/MyPage/ModifyNickname/ModifyNickname.jsx
+++ b/src/components/MyPage/ModifyNickname/ModifyNickname.jsx
@@ -1,13 +1,32 @@
 import { useState } from 'react';
-import * as S from './Styles'; // 필요한 스타일 임포트
+import * as S from './Styles'; 
+import { updateNickname } from 'api/Mypage/UpdateNickname';
 
 const ModifyNickname = ({ isOpen, onClose }) => {
   const [nickname, setNickname] = useState('');
-  const isFormComplete = nickname;
+  const [isNicknameValid, setIsNicknameValid] = useState(true);
+  const isFormComplete = nickname && isNicknameValid;
   
-  const handleSave = () => {
-    console.log('저장된 닉네임:', nickname);
-    onClose();
+  const handleUpdateNickname = (e) => {
+    const value = e.target.value;
+    setNickname(value);
+    setIsNicknameValid(value.length >= 2 && value.length <= 7);
+  };
+  
+
+  const handleSave = async () => {
+    try {
+      const response = await updateNickname({ nickname });
+      if (response) {
+        alert('닉네임이 성공적으로 업데이트되었습니다.');
+        onClose();
+        window.location.reload();
+      } else {
+        alert('닉네임 업데이트에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch (error) {
+      alert('서버 오류가 발생했습니다.');
+    }
   };
 
   if (!isOpen) return null;
@@ -20,10 +39,10 @@ const ModifyNickname = ({ isOpen, onClose }) => {
         <S.MNInput 
           type="text" 
           value={nickname} 
-          onChange={(e) => setNickname(e.target.value)} 
+          onChange={handleUpdateNickname} 
           placeholder="나를 표현할 닉네임을 입력해주세요." 
         />
-
+        {!isNicknameValid && <S.ErrorMessage>2글자 이상 7글자 이하로 작성해주세요.</S.ErrorMessage>}
         <S.BtnContainer>
           <S.CancelBtn onClick={onClose}>취소</S.CancelBtn>
           <S.SaveBtn disabled={!isFormComplete} onClick={handleSave}>저장하기</S.SaveBtn>          

--- a/src/components/MyPage/ModifyNickname/Styles.js
+++ b/src/components/MyPage/ModifyNickname/Styles.js
@@ -58,6 +58,7 @@ export const MNInput = styled.input`
 
 
 export const BtnContainer = styled.div`
+  padding-top: 2%;
   width: 100%;
   display: flex;
   justify-content: space-between;
@@ -80,4 +81,11 @@ export const SaveBtn = styled.button`
   border-radius: 0.8rem;
   background-color: ${({ disabled }) => (disabled ? '#ececec' : '#ea4335')};
   color: ${({ disabled }) => (disabled ? '#7c7c7c' : 'white')};
+`;
+
+//에러메세지
+export const ErrorMessage = styled.div`
+  color: red;
+  font-size: 12px;
+  margin: -2.5% 0 6% 3%;
 `;

--- a/src/pages/MyPage/ModifyEmoji.jsx/ModifyEmoji.jsx
+++ b/src/pages/MyPage/ModifyEmoji.jsx/ModifyEmoji.jsx
@@ -1,36 +1,56 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './Styles';
-import { useSetRecoilState } from 'recoil';
-import { emojiState } from 'recoil/state/emojiState';
 import * as M from 'utils/IconMapper';
+import { updateEmoji } from 'api/Mypage/UpdateEmoji';
 
 const SelectEmoji = () => {
   const navigate = useNavigate();
-  const setEmoji = useSetRecoilState(emojiState);
   const [selectedEmoji, setSelectedEmoji] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleBack = () => {
     navigate(-1);
   };
 
-  const emojis = M.getAllEmojis(); // 이모지 목록
+  const emojis = M.getAllEmojis();
 
   const handleSelect = (emoji) => {
-    const emojiImage = M.getImageByEmoji(emoji);  // 이미지 URL
-    setSelectedEmoji(emojiImage); 
+    setSelectedEmoji(emoji); 
   };
 
-  const handleSubmit = (e) => {
-    e.preventDefault(); 
 
+  useEffect(() => {
+    console.log("현재 선택된 이모지:", selectedEmoji);
+  }, [selectedEmoji]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+  
+    // console.log("response data:", JSON.stringify({ emoji: selectedEmoji })); 
+  
     if (selectedEmoji) {
-      setEmoji(selectedEmoji);  
-      navigate('/modifyprofile'); 
+      setIsLoading(true);
+      try {
+        const response = await updateEmoji({ emoji: selectedEmoji }); 
+        // console.log("서버 응답:", response); 
+        if (response) {
+          alert('이모지가 성공적으로 업데이트되었습니다.');
+          navigate('/modifyprofile');
+        } else {
+          alert('이모지 업데이트에 실패했습니다. 다시 시도해주세요.');
+        }
+      } catch (error) {
+        // console.error("에러:", error.response?.data || error.message); 
+        alert('서버 오류가 발생했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
     } else {
-      alert('이모지를 선택해주세요!'); 
+      alert('이모지를 선택해주세요!');
     }
   };
+  
 
   return (
     <S.JoinContainer>
@@ -51,7 +71,7 @@ const SelectEmoji = () => {
                 key={index}
                 onClick={() => handleSelect(emoji)}
               >
-                <S.EmojiWrap isSelected={selectedEmoji === emojiImage}>
+                <S.EmojiWrap isSelected={selectedEmoji === emoji}>
                   <S.TossEmoji>
                     <img src={emojiImage} alt={emoji} />
                   </S.TossEmoji>

--- a/src/pages/MyPage/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/MyPage/ModifyProfile/ModifyProfile.jsx
@@ -6,7 +6,6 @@ import ModifyNickname from 'components/MyPage/ModifyNickname/ModifyNickname';
 import { getmyProfile } from 'api/Mypage/GetmyProfile';
 import { getImageByEmoji } from 'utils/IconMapper';
 import { mappingStyle, mappingAge, mappingFace } from 'data/SignUpData';
-import { Header } from '../../../components/Common/Header/Header/Header';
 
 const ModifyProfile = () => {
   const navigate = useNavigate();
@@ -52,7 +51,6 @@ const ModifyProfile = () => {
         <S.BackBtn onClick={handleBack} />
         <S.TopBarText>프로필 수정</S.TopBarText>
       </S.TopBarContainer>
-      <Header title='프로필 수정' />
 
       {isLoading? (
         <>

--- a/src/pages/MyPage/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/MyPage/ModifyProfile/ModifyProfile.jsx
@@ -1,14 +1,19 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './Styles';
 import ModifyNickname from 'components/MyPage/ModifyNickname/ModifyNickname';
-import { useRecoilState } from 'recoil';
-import { emojiState } from 'recoil/state/emojiState';
+
+import { getmyProfile } from 'api/Mypage/GetmyProfile';
+import { getImageByEmoji } from 'utils/IconMapper';
+import { mappingStyle, mappingAge, mappingFace } from 'data/SignUpData';
+import { Header } from '../../../components/Common/Header/Header/Header';
 
 const ModifyProfile = () => {
   const navigate = useNavigate();
   const [isModalOpen, setModalOpen] = useState(false);
-  const [selectedEmoji, setSelectedEmoji] = useRecoilState(emojiState); // Recoil 상태로 선택된 이모지 가져오기
+
+  const [myProfileData, setMyProfileData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleBack = () => {
     navigate(-1);
@@ -19,8 +24,27 @@ const ModifyProfile = () => {
   };
 
   const handleEmojiClick = () => {
-    navigate('/modifyemoji'); // 이모지를 변경할 수 있는 페이지로 이동
+    navigate('/modifyemoji'); 
   };
+
+  useEffect(() => {
+    const fetchMyProfile = async () => {
+      try {
+        const response = await getmyProfile();
+        if (response) {
+          setMyProfileData(response);
+        } else {
+          setMyProfileData(null);
+        }
+      } catch (error) {
+        console.error('Error fetching profile data:', error);
+        setMyProfileData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchMyProfile();
+  }, []);
 
   return (
     <S.JoinContainer>
@@ -28,91 +52,103 @@ const ModifyProfile = () => {
         <S.BackBtn onClick={handleBack} />
         <S.TopBarText>프로필 수정</S.TopBarText>
       </S.TopBarContainer>
+      <Header title='프로필 수정' />
 
-      <S.ContentContainer>
-        <S.EmojiContainer>
-          <S.CircleWrap className='emoji' onClick={handleEmojiClick}>
-            <S.EmojiWrap>
-              <S.TossEmoji>
-                <img src={selectedEmoji} alt="Selected Emoji" />
-              </S.TossEmoji>
-            </S.EmojiWrap>
-          </S.CircleWrap>
-          <S.Text>이모지를 눌러서 바꿔보세요!</S.Text>
-        </S.EmojiContainer>
+      {isLoading? (
+        <>
+          <S.ProfileValues>로딩 중 입니다.</S.ProfileValues>
+        </>
+      ) : myProfileData? (
+        <>
+          <S.ContentContainer>
+            <S.EmojiContainer>
+              <S.CircleWrap className='emoji' onClick={handleEmojiClick}>
+                <S.EmojiWrap>
+                  <S.TossEmoji src={getImageByEmoji(myProfileData.data.emoji)} ></S.TossEmoji>
+                </S.EmojiWrap>
+              </S.CircleWrap>
+              <S.Text>이모지를 눌러서 바꿔보세요!</S.Text>
+            </S.EmojiContainer>
 
-        <S.ProfileContainer>
-          <S.ProfileWrapper>
-            <S.ProfileItems>이름</S.ProfileItems>
-            <S.ProfileValues>장세연</S.ProfileValues>
-          </S.ProfileWrapper>
-          <S.ProfileWrapper onClick={handleNicknameClick} style={{ cursor: 'pointer' }}>
-            <S.ProfileItems>닉네임</S.ProfileItems>
-            <S.ProfileValues className='nickname'>불명</S.ProfileValues>
-          </S.ProfileWrapper>
-          <S.ProfileWrapper>
-            <S.ProfileItems>학과/계열</S.ProfileItems>
-            <S.ProfileValues>정보통신전자공학부</S.ProfileValues>
-          </S.ProfileWrapper>
-          <S.ProfileWrapper>
-            <S.ProfileItems>학번</S.ProfileItems>
-            <S.ProfileValues>202121346</S.ProfileValues>
-          </S.ProfileWrapper>
-          <S.ProfileWrapper>
-            <S.ProfileItems>학년 | 나이</S.ProfileItems>
-            <S.ProfileValues>4학년 | 24세</S.ProfileValues>
-          </S.ProfileWrapper>
-          <S.ProfileWrapper>
-            <S.ProfileItems>MBTI</S.ProfileItems>
-            <S.ProfileValues>ESFJ</S.ProfileValues>
-          </S.ProfileWrapper>
-        </S.ProfileContainer>
+            <S.ProfileContainer>
+              <S.ProfileWrapper>
+                <S.ProfileItems>이름</S.ProfileItems>
+                <S.ProfileValues>{myProfileData.data.name}</S.ProfileValues>
+              </S.ProfileWrapper>
+              <S.ProfileWrapper onClick={handleNicknameClick} style={{ cursor: 'pointer' }}>
+                <S.ProfileItems>닉네임</S.ProfileItems>
+                <S.ProfileValues className='nickname'>{myProfileData.data.nickname}</S.ProfileValues>
+              </S.ProfileWrapper>
+              <S.ProfileWrapper>
+                <S.ProfileItems>학과/계열</S.ProfileItems>
+                <S.ProfileValues>{myProfileData.data.major}</S.ProfileValues>
+              </S.ProfileWrapper>
+              <S.ProfileWrapper>
+                <S.ProfileItems>학번</S.ProfileItems>
+                <S.ProfileValues>{myProfileData.data.studentNumber}</S.ProfileValues>
+              </S.ProfileWrapper>
+              <S.ProfileWrapper>
+                <S.ProfileItems>학년 | 나이</S.ProfileItems>
+                <S.ProfileValues>{myProfileData.data.grade} | {myProfileData.data.age}</S.ProfileValues>
+              </S.ProfileWrapper>
+              <S.ProfileWrapper>
+                <S.ProfileItems>MBTI</S.ProfileItems>
+                <S.ProfileValues>{myProfileData.data.mbti}</S.ProfileValues>
+              </S.ProfileWrapper>
+            </S.ProfileContainer>
 
-        <S.PreferContainer>
-          <S.PreferWrapper>
-            <S.CircleWrap>
-              <S.EmojiWrap>
-                <S.PreferValue>ESFJ</S.PreferValue>
-              </S.EmojiWrap>
-            </S.CircleWrap>
-            <S.Text>MBTI</S.Text>
-          </S.PreferWrapper>
+            <S.PreferContainer>
+              <S.PreferWrapper>
+                <S.CircleWrap>
+                  <S.EmojiWrap>
+                    <S.PreferValue>{myProfileData.data.mbti}</S.PreferValue>
+                  </S.EmojiWrap>
+                </S.CircleWrap>
+                <S.Text>MBTI</S.Text>
+              </S.PreferWrapper>
 
-          <S.PreferWrapper>
-            <S.CircleWrap>
-              <S.EmojiWrap>
-                <S.PreferValue>큐티</S.PreferValue>
-              </S.EmojiWrap>
-            </S.CircleWrap>
-            <S.Text>스타일</S.Text>
-          </S.PreferWrapper>
+              <S.PreferWrapper>
+                <S.CircleWrap>
+                  <S.EmojiWrap>
+                    <S.PreferValue>{mappingStyle(myProfileData.data.style)}</S.PreferValue>
+                  </S.EmojiWrap>
+                </S.CircleWrap>
+                <S.Text>스타일</S.Text>
+              </S.PreferWrapper>
 
-          <S.PreferWrapper>
-            <S.CircleWrap>
-              <S.EmojiWrap className='blue'>
-                <S.PreferValue>공룡</S.PreferValue>
-              </S.EmojiWrap>
-            </S.CircleWrap>
-            <S.Text>이상형</S.Text>
-          </S.PreferWrapper>
+              <S.PreferWrapper>
+                <S.CircleWrap>
+                  <S.EmojiWrap className='blue'>
+                    <S.PreferValue>{mappingFace(myProfileData.data.idealType)}</S.PreferValue>
+                  </S.EmojiWrap>
+                </S.CircleWrap>
+                <S.Text>이상형</S.Text>
+              </S.PreferWrapper>
 
-          <S.PreferWrapper>
-            <S.CircleWrap>
-              <S.EmojiWrap className='blue'>
-                <S.PreferValue>연상</S.PreferValue>
-              </S.EmojiWrap>
-            </S.CircleWrap>
-            <S.Text>선호나이</S.Text>
-          </S.PreferWrapper>
-        </S.PreferContainer>
+              <S.PreferWrapper>
+                <S.CircleWrap>
+                  <S.EmojiWrap className='blue'>
+                    <S.PreferValue>{mappingAge(myProfileData.data.idealAge)}</S.PreferValue>
+                  </S.EmojiWrap>
+                </S.CircleWrap>
+                <S.Text>선호나이</S.Text>
+              </S.PreferWrapper>
+            </S.PreferContainer>
 
-        <S.BtnContainer>
-          <S.Text>닉네임과 이모지만 변경할 수 있어요.</S.Text>
-          <S.ModifyBtn>
-            변경된 내용이 없어요.
-          </S.ModifyBtn>
-        </S.BtnContainer>
-      </S.ContentContainer>
+            <S.BtnContainer>
+              <S.Text>닉네임과 이모지만 변경할 수 있어요.</S.Text>
+              <S.ModifyBtn>
+                변경된 내용이 없어요.
+              </S.ModifyBtn>
+            </S.BtnContainer>
+          </S.ContentContainer>
+        </>
+      ) : (
+        <>
+          <S.PreferValue>로그인이 필요한 페이지 입니다.</S.PreferValue>
+        </>
+      )}
+
 
       <ModifyNickname isOpen={isModalOpen} onClose={() => setModalOpen(false)} />
     </S.JoinContainer>

--- a/src/pages/MyPage/ModifyProfile/Styles.js
+++ b/src/pages/MyPage/ModifyProfile/Styles.js
@@ -6,6 +6,7 @@ export const JoinContainer = styled.div`
   height: 100%;
   background-color: white;
   font-family: Pretendard;
+  overflow-y: auto;
 `;
 
 //상단바
@@ -71,13 +72,15 @@ export const EmojiWrap = styled.div`
   align-items: center;
   font-size: 55px;
   border-radius: 50%; 
+  color: #EA4335;
 
   &.blue {
     background-color: rgba(66, 133, 244, 0.1);
     color: rgb(66, 133, 244);
   }
 `;
-export const TossEmoji = styled.div`
+export const TossEmoji = styled.img`
+  width: 70%; height: 70%;
 `;
 export const Text = styled.p`
   font-size: 12px;
@@ -130,11 +133,12 @@ export const PreferItems = styled.p`
 export const BtnContainer = styled.div`
   padding: 5% 0;
   height: 100%;
+  text-align: center;
 `;
 
 export const ModifyBtn = styled.button`
   font-weight: 700;
-  width: 100%; height: 100%;
+  width: 90%; height: 100%;
   padding: 4%;
   border-radius: 0.6rem;
   background-color: ${({ disabled }) => (disabled ? '#ececec' : '#ea4335')};


### PR DESCRIPTION
## 🏁 요약
- ex) ZI밋 팀 만들기 생성
- 관련 이슈 #196 
  - close #196 

<br>


## ✨ 주요 변경점
- 회원정보수정 메인페이지 api 연결
- 닉네임 변경 api 연결
- 이모지 변경 api 연결

<br>


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/560a4370-5d5a-4b5f-833d-7e404cfaecf8)

<br>

