### PR TITLE
[#276] 카카오톡 채널, 이체 확인 링크 수정

### DIFF
--- a/src/components/MyPage/QnA/QnA.jsx
+++ b/src/components/MyPage/QnA/QnA.jsx
@@ -30,7 +30,7 @@ const QnA = ({ myProfileData }) => {
                     <S.AlarmText>눌러서 하이 받을 때, 채팅 올 때 알림 받기</S.AlarmText>
                 </S.AlarmButton>
             )}
-            <S.QnAs onClick={() => handleNavigate('http://pf.kakao.com/_uVsTn/chat', '마이_1대1문의하기')}>
+            <S.QnAs onClick={() => handleNavigate('http://pf.kakao.com/_gHxmin', '마이_1대1문의하기')}>
                 <S.QnAContent>1대1 문의하기</S.QnAContent>
                 <View />
             </S.QnAs>

--- a/src/components/MyPage/StoreInfoButton/StoreInfoButton.tsx
+++ b/src/components/MyPage/StoreInfoButton/StoreInfoButton.tsx
@@ -1,0 +1,15 @@
+import * as S from './Styles';
+
+const StoreInfoButton = () => {
+    const handleClick = () => {
+        window.location.href = 'http://pf.kakao.com/_gHxmin';
+    };
+
+    return (
+        <S.StoreInfoButtonLayout onClick={handleClick}>
+            상점에서 결제 후 눌러서 정보를 보내주세요!
+        </S.StoreInfoButtonLayout>
+    );
+};
+
+export default StoreInfoButton; 

--- a/src/components/MyPage/StoreInfoButton/Styles.ts
+++ b/src/components/MyPage/StoreInfoButton/Styles.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const StoreInfoButtonLayout = styled.div`
+    width: 90%;
+    height: 7%;
+    margin: 2% auto 0 auto;
+    background-color: #EA4335;
+    color: white;
+    border-radius: 0.8rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: Pretendard, sans-serif;
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+    cursor: pointer;
+`; 

--- a/src/pages/MyPage/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage/MyPage.tsx
@@ -15,6 +15,7 @@ import ModalLogout from 'components/MyPage/ModalLogout/ModalLogout';
 import useLoginCheck from 'api/Authentication/useLoginCheck';
 import { track } from '@amplitude/analytics-browser';
 import { MyProfileResponseType } from 'recoilStores/type/MyPage/MyProfileType';
+import StoreInfoButton from 'components/MyPage/StoreInfoButton/StoreInfoButton';
 
 const MyPage = () => {
   const isLoggedIn = localStorage.getItem('accessToken') ? true : false;
@@ -137,6 +138,7 @@ const MyPage = () => {
           ZI밋 출시 기념! 오직 2025 아우름제에서만 이 가격으로!
         </S.Text>
         <Item />
+        <StoreInfoButton />
         {myProfileData && ( <ItemShop />)}
         <QnA myProfileData={myProfileData}/>
 


### PR DESCRIPTION
## 🏁 요약
- 기존에 사용하던 카카오톡 채널, 알림 설정 등 링크의 변동으로 수정
- 관련 이슈
  - close #276 

<br>


## ✨ 주요 변경점
- [x] 카카오톡 채널 (문의하기)
- [x] 이체 확인 오픈채팅 링크 추가

<br>


## 📸 스크린샷
![Image](https://github.com/user-attachments/assets/813c65c3-b146-4741-9396-5810a456a6d7)
<br>
